### PR TITLE
Use zune-jpeg for JPEG decode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1595,6 +1595,7 @@ dependencies = [
  "tempfile",
  "tracing",
  "walkdir",
+ "zune-jpeg 0.5.8",
 ]
 
 [[package]]
@@ -2662,8 +2663,8 @@ dependencies = [
  "rayon",
  "rgb",
  "tiff",
- "zune-core",
- "zune-jpeg",
+ "zune-core 0.4.12",
+ "zune-jpeg 0.4.21",
 ]
 
 [[package]]
@@ -5073,7 +5074,7 @@ dependencies = [
  "half",
  "quick-error",
  "weezl",
- "zune-jpeg",
+ "zune-jpeg 0.4.21",
 ]
 
 [[package]]
@@ -6816,6 +6817,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
 
 [[package]]
+name = "zune-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111f7d9820f05fd715df3144e254d6fc02ee4088b0644c0ffd0efc9e6d9d2773"
+
+[[package]]
 name = "zune-inflate"
 version = "0.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6830,7 +6837,16 @@ version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
- "zune-core",
+ "zune-core 0.4.12",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35aee689668bf9bd6f6f3a6c60bb29ba1244b3b43adfd50edd554a371da37d5"
+dependencies = [
+ "zune-core 0.5.0",
 ]
 
 [[package]]

--- a/crates/feeder_core/Cargo.toml
+++ b/crates/feeder_core/Cargo.toml
@@ -16,6 +16,7 @@ safetensors = "0.6.2"
 serde = { version = "1.0.228", features = ["derive"] }
 tracing = "0.1.41"
 walkdir = "2.5.0"
+zune-jpeg = "0.5.8"
 
 [dev-dependencies]
 tempfile = "3.23.0"


### PR DESCRIPTION
## Summary\n- decode JPEGs with zune-jpeg into RGB buffers\n- keep PNG/other formats on image::open\n- reuse fast_image_resize for square resize and normalization\n\n## Testing\n- ./scripts/ci.ps1\n\nRefs #7