### PR TITLE
Avoid bundling libxkbcommon in AppImage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.1] - Unreleased
+
+### Fixed
+- Linux AppImage avoids bundling libxkbcommon to prevent keyboard input crashes on newer distros (issue #4).
+
 ## [1.3.0] - 2026-01-04
 
 ### Added


### PR DESCRIPTION
## Summary
- remove bundled libxkbcommon from the AppImage so the system lib matches host X11 compose data
- package AppImage with appimagetool after cleanup to avoid keyboard-triggered segfaults
- add 1.3.1 changelog note

## Testing
- not run (packaging-only change)

Refs #4